### PR TITLE
expose env variable to browser

### DIFF
--- a/frontend/src/api/CompassApi.tsx
+++ b/frontend/src/api/CompassApi.tsx
@@ -1,4 +1,3 @@
-import { env } from 'process';
 import { Configuration, DaySheetControllerApi } from './compassClient'; // Adjust the import path as necessary
 import axios from 'axios';
 
@@ -6,7 +5,7 @@ class CompassApi {
   getApiConfiguration = () => {
     return this.fetchAccessToken().then(accessToken => {
       return new Configuration({
-        basePath: env.REACT_APP_API_BASE_PATH, // Use the environment variable for the base path
+        basePath: process.env.NEXT_PUBLIC_API_BASE_PATH,
         baseOptions: {
           headers: {
             Authorization: `Bearer ${accessToken}`,


### PR DESCRIPTION
switched to NEXT_PUBLIC_API_BASE_PATH

_Non-NEXT_PUBLIC_ environment variables are only available in the Node.js environment, meaning they aren't accessible to the browser (the client runs in a different environment)._
https://nextjs.org/docs/pages/building-your-application/configuring/environment-variables#bundling-environment-variables-for-the-browser